### PR TITLE
Update minecraft versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = "app.simplecloud.plugin"
-    version = "0.0.1"
+    version = "0.0.2"
 
     repositories {
         mavenCentral()

--- a/registration-bungeecord/build.gradle.kts
+++ b/registration-bungeecord/build.gradle.kts
@@ -26,7 +26,11 @@ modrinth {
         "1.21.1",
         "1.21.2",
         "1.21.3",
-        "1.21.4"
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8"
     )
     loaders.add("bungeecord")
     changelog.set("https://docs.simplecloud.app/changelog")

--- a/registration-velocity/build.gradle.kts
+++ b/registration-velocity/build.gradle.kts
@@ -46,7 +46,11 @@ modrinth {
         "1.21.1",
         "1.21.2",
         "1.21.3",
-        "1.21.4"
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8"
     )
     loaders.add("velocity")
     changelog.set("https://docs.simplecloud.app/changelog")


### PR DESCRIPTION
This pull request updates the supported versions for the `modrinth` configuration in both the `registration-bungeecord` and `registration-velocity` projects by adding newer versions.

### Version updates:

* [`registration-bungeecord/build.gradle.kts`](diffhunk://#diff-ec358a2e520bab399b2a1bcea71bdbeb10a326b6707ffa8f13cfac54cf5886eaL29-R33): Added support for versions `1.21.5`, `1.21.6`, `1.21.7`, and `1.21.8` in the `modrinth` configuration.
* [`registration-velocity/build.gradle.kts`](diffhunk://#diff-6b66db7554077a214ab4172c3b2e593d0e560b479c8d06ead7fed79d5f721a80L49-R53): Added support for versions `1.21.5`, `1.21.6`, `1.21.7`, and `1.21.8` in the `modrinth` configuration.